### PR TITLE
Cut docker image size in half.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ FROM squidfunk/mkdocs-material AS base
 WORKDIR /docs/
 
 # copy files from local repo
-COPY ./docs ./docs
-COPY ./server ./server
-COPY ./mkdocs.yml ./mkdocs.yml
-COPY ./build-docs.sh ./build-docs.sh
 COPY ./package.json ./package.json
 
 # install dependencies
@@ -15,10 +11,26 @@ RUN pip3 install mkdocs-video \
 	&& apk add --update nodejs npm zip bash \
 	&& npm install
 
+# copy code/docs after installing dependencies to improve
+# build cache performance.
+COPY ./docs ./docs
+COPY ./server ./server
+COPY ./mkdocs.yml ./mkdocs.yml
+COPY ./build-docs.sh ./build-docs.sh
+
 # build the docs
 RUN chmod +x ./build-docs.sh \
 	&& bash ./build-docs.sh
 
+FROM node:20-alpine AS deploy
+
+WORKDIR /docs/
+
+# Copy built docs and runtime dependencies (server/node_modules).
+# Ignore build time tools.
+COPY --from=base /docs/build ./build
+COPY --from=base /docs/server ./server
+COPY --from=base /docs/node_modules ./node_modules
 # uncomment to hang and debug the image
 # ENTRYPOINT [ "tail", "-f", "/dev/null" ]
 


### PR DESCRIPTION
Use `multi-stage docker image`, an `alpine` base image, and improve the docker `layer order` to make it cache and deploy friendly.

Image deployments should be a lot faster because we're only pushing necessary changes. This reduces the image to the bare minimum we need
- built docs
- node_modules and scripts for serving docs.

Took the image size from ~400mb to ~200mb.
